### PR TITLE
add shipping_delay to capture data

### DIFF
--- a/src/main/java/com/klarna/rest/api/model/CaptureData.java
+++ b/src/main/java/com/klarna/rest/api/model/CaptureData.java
@@ -76,6 +76,15 @@ public class CaptureData extends Model {
     private List<ShippingInfo> shippingInfo;
 
     /**
+     * Delay before the order will be shipped. Use for improving the customer
+     * experience regarding payments. This field is currently not returned when
+     * reading the order. Minimum: 0. Please note: to be able to submit values
+     * larger than 0, this has to be enabled in your merchant account. Please
+     * contact Klarna for further information.
+     */
+    private Integer shippingDelay;
+
+    /**
      * Gets the capture id.
      *
      * @return Capture id
@@ -223,5 +232,19 @@ public class CaptureData extends Model {
         this.shippingInfo = info;
 
         return this;
+    }
+
+    /**
+     * @return the shippingDelay
+     */
+    public Integer getShippingDelay() {
+        return shippingDelay;
+    }
+
+    /**
+     * @param shippingDelay the shippingDelay to set
+     */
+    public void setShippingDelay(Integer shippingDelay) {
+        this.shippingDelay = shippingDelay;
     }
 }

--- a/src/test/java/com/klarna/rest/api/model/CaptureDataTest.java
+++ b/src/test/java/com/klarna/rest/api/model/CaptureDataTest.java
@@ -59,6 +59,14 @@ public class CaptureDataTest extends TestCase {
     }
 
     @Test
+    public void testGetShippingDelay() {
+        assertNull(data.getShippingDelay());
+
+        data.setShippingDelay(3);
+        assertEquals(Integer.valueOf(3), data.getShippingDelay());
+    }
+
+    @Test
     public void testGetOrderLines() {
         assertNull(data.getOrderLines());
 


### PR DESCRIPTION
Issue #5 
The API documentation mentions a shipping_delay field, but this is not present in the CaptureData class, and therefore cannot be sent using the Java SDK.