### PR TITLE
Gets the response family directly from status integer

### DIFF
--- a/src/main/java/com/klarna/rest/model/ApiResponse.java
+++ b/src/main/java/com/klarna/rest/model/ApiResponse.java
@@ -214,7 +214,7 @@ public class ApiResponse {
      * @see ErrorMessage
      */
     public ApiResponse expectSuccessful() throws ApiException {
-        Family family = Status.fromStatusCode(this.getStatus()).getFamily();
+        Family family = Family.familyOf(this.getStatus());
 
         if (family.equals(SUCCESSFUL)) {
             return this;

--- a/src/test/java/com/klarna/rest/ApiResponseTest.java
+++ b/src/test/java/com/klarna/rest/ApiResponseTest.java
@@ -136,4 +136,17 @@ public class ApiResponseTest extends TestCase {
             assertEquals("111: Wrong order_total (#123-123-123)", e.getMessage());
         }
     }
+
+    @Test
+    public void testAbsentResponseCode() {
+        try {
+            response.setStatus(422);
+            response.setBody("{ \"error_code\" : \"UNPROCESSABLE_ENTITY\", \"error_messages\" : [\"'refunded_amount' may not be null\"], \"correlation_id\" : \"123-123-123\" }".getBytes());
+            response.expectSuccessful();
+            fail();
+        } catch (ApiException e) {
+            System.out.println(e);
+            assertEquals("UNPROCESSABLE_ENTITY: 'refunded_amount' may not be null (#123-123-123)", e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
Fixes #39 on v3.x